### PR TITLE
Разработчик Simple написал, что лучше оставить атрибут href пустым

### DIFF
--- a/src/catalog/view/theme/default/template/payment/yandexmoney.tpl
+++ b/src/catalog/view/theme/default/template/payment/yandexmoney.tpl
@@ -74,7 +74,7 @@ endif; ?>
 
         <div class="buttons">
             <div class="right">
-                <a href="javascript://" id="button-confirm" name="submit-button" class="button"><?php echo $button_confirm; ?></a>
+                <a href="" id="button-confirm" name="submit-button" class="button"><?php echo $button_confirm; ?></a>
             </div>
         </div>
     </form>


### PR DESCRIPTION
https://opencartforum.com/topic/45529-platno-prostaya-registraciya-i-zakaz-simple-3431/?page=476&tab=comments#comment-853535
Это решает проблему отсутствия редиректа на платёжную систему.